### PR TITLE
Add Streamlit Excel filter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # sewage_ai
+
+This repository contains small Streamlit apps for data analysis. The `filter_app.py` script demonstrates how to load an Excel file, filter it by multiple conditions and optionally request a short summary from an LLM using Langchain.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the Streamlit app:
+   ```bash
+   streamlit run filter_app.py
+   ```
+3. Upload an Excel file and interact with the filters on screen.

--- a/filter_app.py
+++ b/filter_app.py
@@ -1,0 +1,33 @@
+import streamlit as st
+import pandas as pd
+from langchain.chat_models import ChatOpenAI
+from langchain.schema import SystemMessage, HumanMessage
+
+st.set_page_config(page_title="엑셀 데이터 필터링", layout="wide")
+st.title("📊 엑셀 데이터 다중 조건 필터")
+
+uploaded_file = st.file_uploader("엑셀 파일 업로드", type=["xls", "xlsx"])
+
+if uploaded_file is not None:
+    df = pd.read_excel(uploaded_file)
+    st.subheader("데이터 미리보기")
+    st.write(df.head())
+
+    st.subheader("필터 조건 설정")
+    filter_columns = st.multiselect("필터할 컬럼 선택", df.columns)
+    filtered_df = df.copy()
+    for col in filter_columns:
+        unique_vals = df[col].unique().tolist()
+        selected_vals = st.multiselect(f"{col} 값 선택", unique_vals)
+        if selected_vals:
+            filtered_df = filtered_df[filtered_df[col].isin(selected_vals)]
+
+    st.subheader("필터링 결과")
+    st.write(filtered_df)
+
+    if st.checkbox("LLM에게 요약 요청"):
+        llm = ChatOpenAI()
+        system_msg = SystemMessage(content="너는 데이터 분석 도우미야. 사용자에게 친절하게 답변해.")
+        user_msg = HumanMessage(content=f"다음 데이터에 대한 간단한 요약을 해줘:\n{filtered_df.head().to_string()}")
+        response = llm([system_msg, user_msg])
+        st.write(response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ protobuf==3.20.0
 markdown
 pypdf
 openpyxl
+pandas
+langchain


### PR DESCRIPTION
## Summary
- add a simple Streamlit app `filter_app.py` that loads an Excel file and lets the user filter rows by multiple columns, with an optional LLM summary via Langchain
- update dependencies to include `pandas` and `langchain`
- expand the README with instructions for running the new app

## Testing
- `python -m py_compile filter_app.py seage_ai_front.py`

------
https://chatgpt.com/codex/tasks/task_e_685aae4ad2908332a27d1e79799a17e5